### PR TITLE
Add environment override

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,13 @@
 import arrify from 'arrify';
 import detectors from './detectors';
 
+const { COMMIT_CONVENTION_OVERRIDE } = process.env;
+
 export default (commits) => {
+  if (detectors[COMMIT_CONVENTION_OVERRIDE]) {
+    return COMMIT_CONVENTION_OVERRIDE;
+  }
+  
   commits = arrify(commits);
 
   let tally = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ import arrify from 'arrify';
 import detectors from './detectors';
 
 export default (commits) => {
-  const { COMMIT_CONVENTION_OVERRIDE } = process.env;
+  let { COMMIT_CONVENTION_OVERRIDE } = process.env;
 
   if (detectors[COMMIT_CONVENTION_OVERRIDE]) {
     return COMMIT_CONVENTION_OVERRIDE;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,13 @@
 import arrify from 'arrify';
 import detectors from './detectors';
 
-const { COMMIT_CONVENTION_OVERRIDE } = process.env;
-
 export default (commits) => {
+  const { COMMIT_CONVENTION_OVERRIDE } = process.env;
+
   if (detectors[COMMIT_CONVENTION_OVERRIDE]) {
     return COMMIT_CONVENTION_OVERRIDE;
   }
-  
+
   commits = arrify(commits);
 
   let tally = {};

--- a/test/index.js
+++ b/test/index.js
@@ -75,7 +75,7 @@ it('should accept an environment override', function () {
 
   const oldEnv = process.env.COMMIT_CONVENTION_OVERRIDE;
   process.env.COMMIT_CONVENTION_OVERRIDE = 'angular';
-  
+
   equal(conventionalCommitsDetector(commits), 'angular');
   process.env.COMMIT_CONVENTION_OVERRIDE = oldEnv;
 });
@@ -92,7 +92,7 @@ it('should ignore an unknown environment override', function () {
 
   const oldEnv = process.env.COMMIT_CONVENTION_OVERRIDE;
   process.env.COMMIT_CONVENTION_OVERRIDE = 'some unknown convention';
-  
+
   equal(conventionalCommitsDetector(commits), 'atom');
   process.env.COMMIT_CONVENTION_OVERRIDE = oldEnv;
 });

--- a/test/index.js
+++ b/test/index.js
@@ -63,3 +63,36 @@ it('should be jshint', function () {
 
   equal(conventionalCommitsDetector(commits), 'jshint');
 });
+
+it('should accept an environment override', function () {
+  // intentionally NOT angular
+  let commits = [
+    ':memo: Fix license',
+    ':memo: Add a screenshot',
+    ':fire: init',
+    'Prepare 0.0.1 release'
+  ];
+
+  const oldEnv = process.env.COMMIT_CONVENTION_OVERRIDE;
+  process.env.COMMIT_CONVENTION_OVERRIDE = 'angular';
+  
+  equal(conventionalCommitsDetector(commits), 'angular');
+  process.env.COMMIT_CONVENTION_OVERRIDE = oldEnv;
+});
+
+
+it('should ignore an unknown environment override', function () {
+  // intentionally NOT angular
+  let commits = [
+    ':memo: Fix license',
+    ':memo: Add a screenshot',
+    ':fire: init',
+    'Prepare 0.0.1 release'
+  ];
+
+  const oldEnv = process.env.COMMIT_CONVENTION_OVERRIDE;
+  process.env.COMMIT_CONVENTION_OVERRIDE = 'some unknown convention';
+  
+  equal(conventionalCommitsDetector(commits), 'atom');
+  process.env.COMMIT_CONVENTION_OVERRIDE = oldEnv;
+});


### PR DESCRIPTION
This pull requests allows the user to override the result via an environment variable.

The use case is for other projects that use this one to determine the style of commit messages without the ability to override that.